### PR TITLE
`SourceSetFileDialog` visual & keyboard / mouse interaction improvements

### DIFF
--- a/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorFileJumpAction.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorFileJumpAction.kt
@@ -57,7 +57,7 @@ class PreprocessorFileJumpAction : DumbAwareAction() {
 
         val caret = editor.caretModel.currentCaret.visualPosition
         SourceSetFileDialog(project, targets) { selected ->
-            val virtualFile = VfsUtil.findFile(rootDirectory.resolve(selected.navigatePath()), true)
+            val virtualFile = VfsUtil.findFile(rootDirectory.resolve(selected.toRelativePath()), true)
             if (virtualFile == null) {
                 warning(
                     project,

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFile.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFile.kt
@@ -6,15 +6,59 @@ data class SourceSetFile(
     val sourceSetName: String,
     val language: String,
     val classPath: Path,
-    val version: String?,
+    val subVersion: String?, // If null, this is the mainVersion in project/src/
+    private val mainVersion: String,
+    private val rootDirectory: Path,
 ) {
+    val isNonGenerated = this.subVersion == null ||
+            toOverridePath()?.let { rootDirectory.resolve(it).toFile().exists() } == true
+
+    val displayVersion = subVersion ?: mainVersion
+
+    // Used to sort entries as 1.8.9 will order before 1.12.2 otherwise
+    val versionInt = displayVersion.split('-').let { platform ->
+        // Convert semantic version to the preprocessor int: 1.21.2 -> 12102
+        fun List<String>.getOrZero(index: Int) = getOrNull(index)?.toIntOrNull() ?: 0
+        val semVer = platform[0].split('.')
+        semVer.getOrZero(0) * 10000 + semVer.getOrZero(1) * 100 + semVer.getOrZero(2)
+    }
+
+    // Simpler search key used to streamline keyboard navigation via search, 1.21.2-fabric -> 12102fabric
+    private val simpleVersion = "$versionInt${displayVersion.split('-')[1]}"
 
     fun toRelativePath(): Path {
-        return if (version == null) {
+        return if (subVersion == null) {
             Path.of("src", sourceSetName, language).resolve(classPath)
         } else {
-            Path.of("versions", version, "build", "preprocessed", sourceSetName, language).resolve(classPath)
+            Path.of("versions", subVersion, "build", "preprocessed", sourceSetName, language).resolve(classPath)
         }
+    }
+
+    // Refers to the path of a possible, non-generated, overriding source file in versions/<subVersion>/src/
+    fun toOverridePath(): Path? {
+        return if (subVersion == null) {
+            null
+        } else {
+            Path.of("versions", subVersion, "src", sourceSetName, language).resolve(classPath)
+        }
+    }
+
+    fun navigatePath(): Path {
+        return if (isNonGenerated) {
+            toOverridePath() ?: toRelativePath()
+        } else {
+            toRelativePath()
+        }
+    }
+
+    override fun toString(): String {
+        val displayFile = classPath.last()
+        val srcMark = if (subVersion == null) "(main)"
+            else if (isNonGenerated) "(override)"
+            else ""
+
+        // e.g. [12102fabric] | 1.21.2-fabric | MyClass.java (main)
+        return "[$simpleVersion] | $displayVersion | $displayFile $srcMark"
     }
 
 }

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFile.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFile.kt
@@ -10,8 +10,24 @@ data class SourceSetFile(
     private val mainVersion: String,
     private val rootDirectory: Path,
 ) {
+    // Refers to the path of a possible, non-generated, overriding source file in versions/<subVersion>/src/
+    private val overridePath: Path? = subVersion?.let {
+        Path.of("versions", it, "src", sourceSetName, language).resolve(classPath)
+    }
+
     val isNonGenerated = this.subVersion == null ||
-            toOverridePath()?.let { rootDirectory.resolve(it).toFile().exists() } == true
+            overridePath?.let { rootDirectory.resolve(it).toFile().exists() } == true
+
+    fun toRelativePath(): Path {
+        return if (subVersion == null) {
+            Path.of("src", sourceSetName, language).resolve(classPath)
+        } else if (isNonGenerated) {
+            overridePath!!
+        } else {
+            Path.of("versions", subVersion, "build", "preprocessed", sourceSetName, language).resolve(classPath)
+        }
+    }
+
 
     val displayVersion = subVersion ?: mainVersion
 
@@ -25,31 +41,6 @@ data class SourceSetFile(
 
     // Simpler search key used to streamline keyboard navigation via search, 1.21.2-fabric -> 12102fabric
     private val simpleVersion = "$versionInt${displayVersion.split('-')[1]}"
-
-    fun toRelativePath(): Path {
-        return if (subVersion == null) {
-            Path.of("src", sourceSetName, language).resolve(classPath)
-        } else {
-            Path.of("versions", subVersion, "build", "preprocessed", sourceSetName, language).resolve(classPath)
-        }
-    }
-
-    // Refers to the path of a possible, non-generated, overriding source file in versions/<subVersion>/src/
-    fun toOverridePath(): Path? {
-        return if (subVersion == null) {
-            null
-        } else {
-            Path.of("versions", subVersion, "src", sourceSetName, language).resolve(classPath)
-        }
-    }
-
-    fun navigatePath(): Path {
-        return if (isNonGenerated) {
-            toOverridePath() ?: toRelativePath()
-        } else {
-            toRelativePath()
-        }
-    }
 
     override fun toString(): String {
         val displayFile = classPath.last()

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -43,7 +43,25 @@ class SourceSetFileDialog(
                 )
             }
         }
+
+        // Double click also triggers doOKAction()
+        addMouseListener(object : MouseAdapter() {
+            private var lastClickTime = 0L
+            private var lastSelectedIndex = -1
+
+            override fun mouseClicked(e: MouseEvent?) {
+                if (e?.button != MouseEvent.BUTTON1) return
+
+                val clickTime = System.currentTimeMillis()
+                if (selectedIndex == lastSelectedIndex && clickTime - lastClickTime < 1000) { // 1 second threshold
+                    doOKAction()
+                }
+                lastClickTime = clickTime
+                lastSelectedIndex = selectedIndex
+            }
+        })
     }
+    private val search = SearchTextField()
 
     init {
         title = "Select Preprocessed Source File"

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -9,6 +9,8 @@ import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import java.awt.BorderLayout
 import java.awt.Component
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.io.File
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JComponent
@@ -68,9 +70,12 @@ class SourceSetFileDialog(
         init()
     }
 
+    // Focus the search field when the dialog is first opened, streamlines keyboard navigation
+    override fun getPreferredFocusedComponent(): JComponent? = search
+
     override fun createCenterPanel(): JComponent {
         val panel = JPanel(BorderLayout())
-        val search = SearchTextField()
+
         search.addDocumentListener(object : DocumentAdapter() {
             override fun textChanged(e: DocumentEvent) {
                 val filter = search.text.lowercase()

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -94,8 +94,10 @@ class SourceSetFileDialog(
                     it.toString().lowercase().contains(filter)
                 })
 
-                // Improve keyboard navigation by auto-selecting the only remaining result
-                if (listModel.size == 1) {
+                if (filter.isEmpty() || listModel.isEmpty) {
+                    list.setSelectedValue(null, false)
+                } else {
+                    // Improve keyboard navigation by auto-selecting the first result
                     list.setSelectedValue(listModel.getElementAt(0), false)
                 }
             }

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -82,6 +82,11 @@ class SourceSetFileDialog(
                 listModel.replaceAll(sourceFiles.filter {
                     it.toRelativePath().toString().lowercase().contains(filter)
                 })
+
+                // Improve keyboard navigation by auto-selecting the only remaining result
+                if (listModel.size == 1) {
+                    list.setSelectedValue(listModel.getElementAt(0), false)
+                }
             }
         })
 

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -4,45 +4,56 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.CollectionListModel
 import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.JBColor
 import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import java.awt.BorderLayout
-import java.awt.Component
+import java.awt.Font
+import java.awt.GridLayout
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import java.io.File
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JComponent
-import javax.swing.JList
+import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.ListCellRenderer
 import javax.swing.ListSelectionModel
 import javax.swing.event.DocumentEvent
 
 class SourceSetFileDialog(
-    private val project: Project,
-    private val mainVersion: String,
-    private val sourceFiles: List<SourceSetFile>,
+    project: Project,
+    sourceFilesUnsorted: List<SourceSetFile>,
     private val onFileChosen: (SourceSetFile) -> Unit
 ) : DialogWrapper(project) {
+
+    private val sourceFiles = sourceFilesUnsorted.sortedBy { it.versionInt }
 
     private val listModel = CollectionListModel(sourceFiles)
     private val list = JBList(listModel).apply {
         selectionMode = ListSelectionModel.SINGLE_SELECTION
-        cellRenderer = object : DefaultListCellRenderer() {
-            override fun getListCellRendererComponent(
-                list: JList<*>?, value: Any?, index: Int,
-                isSelected: Boolean, cellHasFocus: Boolean
-            ): Component {
-                val item = value as SourceSetFile
-                val display = item.version ?: mainVersion
-                return super.getListCellRendererComponent(
-                    list,
-                    "${display}${File.separator}${item.classPath}",
-                    index,
-                    isSelected,
-                    cellHasFocus
-                )
+        cellRenderer = ListCellRenderer<Any> { list, value, index, isSelected, cellHasFocus ->
+            // Use DefaultListCellRenderer to get selection colors etc
+            fun String.label() = DefaultListCellRenderer().getListCellRendererComponent(
+                list,
+                this,
+                index,
+                isSelected,
+                cellHasFocus
+            ).apply {
+                // Further differentiate preprocessed generated files with font style
+                if ((value as SourceSetFile).isNonGenerated) {
+                    font = font.deriveFont(Font.BOLD)
+                }
+            }
+
+            JPanel(GridLayout(1, 2)).apply {
+                val stringParts = value.toString().split("|")
+                add(JPanel(GridLayout(1, 2)).apply {
+                    add(" ${stringParts[0]}".label())
+                    add("| ${stringParts[1]}".label())
+                })
+                add("| ${stringParts[2]}".label())
             }
         }
 
@@ -80,7 +91,7 @@ class SourceSetFileDialog(
             override fun textChanged(e: DocumentEvent) {
                 val filter = search.text.lowercase()
                 listModel.replaceAll(sourceFiles.filter {
-                    it.toRelativePath().toString().lowercase().contains(filter)
+                    it.toString().lowercase().contains(filter)
                 })
 
                 // Improve keyboard navigation by auto-selecting the only remaining result
@@ -91,7 +102,11 @@ class SourceSetFileDialog(
         })
 
         panel.add(search, BorderLayout.NORTH)
-        panel.add(JBScrollPane(list), BorderLayout.CENTER)
+        panel.add(JLabel(" (override) files are, non-generated, override files present in the versions/<version>/src/ directory.").apply {
+                font = font.deriveFont(Font.ITALIC, 12f)
+                foreground = JBColor.GRAY
+            }, BorderLayout.CENTER)
+        panel.add(JBScrollPane(list), BorderLayout.SOUTH)
         return panel
     }
 


### PR DESCRIPTION
## Description
refactor `SourceSet`s and the list for the `PreprocessorJumpAction`:
- corrects list ordering
- support override files from `versions/<version>/src/`
- remove redundant full path from the list string
- layout list cells into nicer columns
- add simple "key" to streamline keyboard searching further
- add indicators for main & override files

also:
- upon filtering the list via search, it auto selects the first result for keyboard navigation streamlining
- focused the search field upon opening for keyboard navigation streamlining
- allows double clicking a list entry to open it immediately

## Related Issue(s)
Fixes #19 
partially fixes #18

## How to test
use the preprocessor file jump dialogue box 

<img width="585" height="378" alt="image" src="https://github.com/user-attachments/assets/dd18ee55-e8fd-4d86-8add-b3cb61b8e3c1" />
<img width="601" height="380" alt="image" src="https://github.com/user-attachments/assets/2d3537d3-1a9e-45e5-9887-413a51ec4954" />


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- Added support for override files within `versions/<version>/src/` to the "jump to preprocessed files" action.
- Improved the visual clarity of the list in the "jump to preprocessed files" dialogue window.
- Improved keyboard navigation of the "jump to preprocessed files" dialogue window.
- Allowed double clicking on entries in the "jump to preprocessed files" dialogue window to open the file.
- Fixed sorting of entries in the "jump to preprocessed files" dialogue window.
```