### PR TITLE
enhance preprocessor block folding so each if/ifdef/elseif/else block can fold separately

### DIFF
--- a/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorFolding.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorFolding.kt
@@ -42,6 +42,23 @@ class PreprocessorFolding : FoldingBuilderEx(), DumbAware {
                     stack.addLast(directive)
                 }
 
+                text.startsWith(directivePrefix + "else") || text.startsWith(directivePrefix + "elseif") -> {
+                    val startDirective = stack.removeLastOrNull()
+                    if (startDirective != null) {
+                        val commentLine = document.getLineNumber(directive.textOffset)
+                        if (commentLine > 0) {
+                            val prevLineEnd = document.getLineEndOffset(commentLine - 1)
+                            descriptors.add(
+                                FoldingDescriptor(
+                                    startDirective,
+                                    TextRange(startDirective.textRange.startOffset, prevLineEnd)
+                                )
+                            )
+                            stack.addLast(directive)
+                        }
+                    }
+                }
+
                 text.startsWith(directivePrefix + "endif") -> {
                     val startDirective = stack.removeLastOrNull()
                     if (startDirective != null) {


### PR DESCRIPTION
## Description
preprocessor comment blocks can now fold each if/ifdef/elseif/else block separately, rather than the entire block from #if -> #endif

specifically `#if` now not only folds to `#endif` but also to the end of the line before any `#else or #elseif` which then starts a new fold from the `#else or #elseif`, which behaves the same way

this makes folding far more usable with nested/complex preprocessor comment blocks, and also sets things up for a possible "collapse inactive blocks by default" option which i want to try add eventually

## How to test
vid example \\/

https://github.com/user-attachments/assets/cf4555bf-4e0a-4350-89fc-3a208579d9b6



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- preprocessor comment blocks can now fold each if/ifdef/elseif/else block separately, rather than the entire block from #if -> #endif
```

