### PR TITLE
new toggle preprocessor comment actions and some fixes

### DIFF
--- a/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleAction.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleAction.kt
@@ -1,0 +1,104 @@
+package org.polyfrost.intelliprocessor.action
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.idea.base.psi.getLineNumber
+import org.polyfrost.intelliprocessor.utils.PreprocessorContainingBlock
+import org.polyfrost.intelliprocessor.utils.activeFile
+import org.polyfrost.intelliprocessor.utils.allPreprocessorDirectiveComments
+
+class PreprocessorCommentToggleAction  : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project: Project = e.project ?: return
+        val editor: Editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return warning(project, "Could not find an open editor")
+        val document = editor.document
+        val file = editor.activeFile ?: return warning(project, "Could not find an opened file")
+
+        val directives = file.allPreprocessorDirectiveComments()
+
+        if (directives.size < 2) return warning(project, "Could not find any preprocessor blocks in this file")
+
+        val block = PreprocessorContainingBlock.getFor(editor.caretModel.offset, directives)
+            ?: return warning(project, "Could not find a preprocessor block at the current caret position")
+
+
+        val startLine = block.directives[block.startIndex].getLineNumber(true) + 1
+        val endLine = block.directives[block.endIndex].getLineNumber(true) - 1
+
+        if (startLine > endLine) return warning(project, "No lines to toggle between the selected directives")
+
+        val excludeLines = block.innerBlocks.map {
+            IntRange(
+                block.directives[it.start].getLineNumber(true),
+            block.directives[it.endInclusive].getLineNumber(true)
+            )
+        }
+
+        val startIndent = countLeadingSpaces(
+            document.getText(TextRange(
+                document.getLineStartOffset(startLine - 1),
+                document.getLineEndOffset(startLine - 1)
+            ))
+        )
+
+        val alreadyHasComments = document.getText(TextRange(
+            document.getLineStartOffset(startLine),
+            document.getLineEndOffset(startLine)
+        )).trim().startsWith("//$$")
+
+        val spaces = " ".repeat(startIndent)
+        val spacedComment = "$spaces//$$ "
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            for (line in startLine..endLine) {
+
+                // Don't modify lines that are part of inner nested blocks
+                if (excludeLines.any { line in it }) continue
+
+                val lineStart = document.getLineStartOffset(line)
+                val lineEnd = document.getLineEndOffset(line)
+                val text = document.getText(TextRange(lineStart, lineEnd))
+
+                // Just remove comments if they are already there
+                if (alreadyHasComments) {
+                    document.replaceString(lineStart, lineEnd,
+                        text.replaceFirst(REPLACE, ""))
+                    continue
+                }
+
+                // If the line is blank, just insert a blank comment
+                if (text.trim().isEmpty()) {
+                    document.replaceString(lineStart, lineEnd, spacedComment)
+                    continue
+                }
+
+                // Only comment lines that are indented at least as much as the block start
+                val indent = countLeadingSpaces(text)
+                if (indent >= startIndent) {
+                    document.replaceString(lineStart, lineEnd,
+                        text.replaceFirst(spaces, spacedComment))
+                }
+            }
+        }
+    }
+
+    private fun countLeadingSpaces(s: String): Int {
+        var count = 0
+        while (count < s.length && s[count] == ' ') count++
+        return count
+    }
+
+    companion object {
+        private val REPLACE = Regex("""//\$\$\s?""")
+
+        private fun warning(project: Project, content: String) {
+            org.polyfrost.intelliprocessor.utils.warning(project, "preprocessor_comment_toggle_failure", content)
+        }
+    }
+}

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleBlockAction.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleBlockAction.kt
@@ -12,7 +12,7 @@ import org.polyfrost.intelliprocessor.utils.PreprocessorContainingBlock
 import org.polyfrost.intelliprocessor.utils.activeFile
 import org.polyfrost.intelliprocessor.utils.allPreprocessorDirectiveComments
 
-class PreprocessorCommentToggleAction  : AnAction() {
+class PreprocessorCommentToggleBlockAction  : AnAction() {
 
     override fun actionPerformed(e: AnActionEvent) {
         val project: Project = e.project ?: return
@@ -47,7 +47,7 @@ class PreprocessorCommentToggleAction  : AnAction() {
             ))
         )
 
-        val alreadyHasComments = document.getText(TextRange(
+        val toggleCommentsOff = document.getText(TextRange(
             document.getLineStartOffset(startLine),
             document.getLineEndOffset(startLine)
         )).trim().startsWith("//$$")
@@ -65,12 +65,10 @@ class PreprocessorCommentToggleAction  : AnAction() {
                 val lineEnd = document.getLineEndOffset(line)
                 val text = document.getText(TextRange(lineStart, lineEnd))
 
-                // Just remove comments if they are already there
-                if (alreadyHasComments) {
-                    document.replaceString(lineStart, lineEnd,
-                        text.replaceFirst(REPLACE, ""))
-                    continue
-                }
+                // Clean up any existing toggle comments
+                document.replaceString(lineStart, lineEnd, text.replaceFirst(REPLACE, ""))
+
+                if (toggleCommentsOff) continue
 
                 // If the line is blank, just insert a blank comment
                 if (text.trim().isEmpty()) {
@@ -83,6 +81,9 @@ class PreprocessorCommentToggleAction  : AnAction() {
                 if (indent >= startIndent) {
                     document.replaceString(lineStart, lineEnd,
                         text.replaceFirst(spaces, spacedComment))
+                } else {
+                    document.replaceString(lineStart, lineEnd,
+                        spacedComment + text.trimStart())
                 }
             }
         }

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleBlockAction.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleBlockAction.kt
@@ -63,12 +63,20 @@ class PreprocessorCommentToggleBlockAction  : AnAction() {
 
                 val lineStart = document.getLineStartOffset(line)
                 val lineEnd = document.getLineEndOffset(line)
-                val text = document.getText(TextRange(lineStart, lineEnd))
+                var text = document.getText(TextRange(lineStart, lineEnd))
+
+                if (text.trimStart().startsWith("//#")) {
+                    warning(project, "Action tried to modify preprocessor directive line at line#${line + 1}, aborting.")
+                    break // something is very wrong abort
+                }
 
                 // Clean up any existing toggle comments
-                document.replaceString(lineStart, lineEnd, text.replaceFirst(REPLACE, ""))
+                text = text.replaceFirst(REPLACE, "")
 
-                if (toggleCommentsOff) continue
+                if (toggleCommentsOff) {
+                    document.replaceString(lineStart, lineEnd, text)
+                    continue
+                }
 
                 // If the line is blank, just insert a blank comment
                 if (text.trim().isEmpty()) {

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleLineAction.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/action/PreprocessorCommentToggleLineAction.kt
@@ -1,0 +1,66 @@
+package org.polyfrost.intelliprocessor.action
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import org.jetbrains.kotlin.idea.base.psi.getLineNumber
+import org.polyfrost.intelliprocessor.utils.PreprocessorContainingBlock
+import org.polyfrost.intelliprocessor.utils.activeFile
+import org.polyfrost.intelliprocessor.utils.allPreprocessorDirectiveComments
+
+class PreprocessorCommentToggleLineAction  : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project: Project = e.project ?: return
+        val editor: Editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return warning(project, "Could not find an open editor")
+        val document = editor.document
+
+        val startLine = editor.caretModel.primaryCaret.selectionStartPosition.line
+        val endLine = editor.caretModel.primaryCaret.selectionEndPosition.line
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            for (line in startLine..endLine) {
+                val lineStart = document.getLineStartOffset(line)
+                val lineEnd = document.getLineEndOffset(line)
+                val text = document.getText(TextRange(lineStart, lineEnd))
+
+                val toggleCommentsOff = text.contains("//$$")
+
+                // Clean up any existing toggle comments
+                document.replaceString(lineStart, lineEnd, text.replaceFirst(REPLACE, ""))
+
+                if (toggleCommentsOff) return@runWriteCommandAction
+
+                // If the line is blank, just insert a blank comment
+                if (text.trim().isEmpty()) {
+                    document.replaceString(lineStart, lineEnd, "//$$ ")
+                    return@runWriteCommandAction
+                }
+
+                // Only comment lines that are indented at least as much as the block start
+                val indent = countLeadingSpaces(text)
+                val spaces = " ".repeat(indent)
+                val spacedComment = "$spaces//$$ "
+                document.replaceString(lineStart, lineEnd, text.replaceFirst(spaces, spacedComment))
+            }
+        }
+    }
+
+    private fun countLeadingSpaces(s: String): Int {
+        var count = 0
+        while (count < s.length && s[count] == ' ') count++
+        return count
+    }
+
+    companion object {
+        private val REPLACE = Regex("""//\$\$\s?""")
+
+        private fun warning(project: Project, content: String) {
+            org.polyfrost.intelliprocessor.utils.warning(project, "preprocessor_comment_toggle_failure", content)
+        }
+    }
+}

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
@@ -55,7 +55,7 @@ val NUMBER_TYPE = HighlightInfoType.HighlightInfoTypeImpl(HighlightSeverity.INFO
 
 private val WHITESPACES_PATTERN = "\\s+".toRegex()
 private val EXPR_PATTERN = "(.+)(==|!=|<=|>=|<|>)(.+)".toRegex()
-private val IDENTIFIER_PATTERN = "[A-Za-z0-9-]+".toRegex()
+private val IDENTIFIER_PATTERN = "!?[A-Za-z0-9-]+".toRegex()
 private val OR_PATTERN = Regex.escape("||")
 private val AND_PATTERN = Regex.escape("&&")
 private val SPLIT_PATTERN = "$OR_PATTERN|$AND_PATTERN".toRegex()

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/SourceSetFileDialog.kt
@@ -92,8 +92,11 @@ class SourceSetFileDialog(
         textEditor.addKeyListener(object : KeyAdapter() {
             override fun keyPressed(e: KeyEvent?) {
                 if (e?.keyCode == KeyEvent.VK_DOWN || e?.keyCode == KeyEvent.VK_KP_DOWN) {
-                    if (list.selectedValue == null) {
-                        list.selectedIndex = 0
+                    if (list.selectedIndex == 0 && listModel.size > 1) {
+                        // Set to 1 as the first index (0) should already be auto-selected meaning we can treat the down
+                        // arrow like moving down as if we were in the list already, (which we kind of are since pressing
+                        // enter will already open the selected item at 0 before this down press)
+                        list.selectedIndex = 1
                     }
                     list.requestFocusInWindow()
                     e.consume()
@@ -124,6 +127,7 @@ class SourceSetFileDialog(
         bottomPanelOrNull()?.let {
             panel.add(it, BorderLayout.SOUTH)
         }
+        filterList()
         return panel
     }
 
@@ -154,7 +158,6 @@ class SourceSetFileDialog(
                     filterList()
                 }
             })
-            filterList()
         }
 
         return if (belowList.isEmpty()) null else JPanel(GridLayout(belowList.size, 1)).apply {
@@ -172,7 +175,7 @@ class SourceSetFileDialog(
                     &&  (!PluginSettings.instance.hideUnmatchedVersions || it.metOpeningCondition)
         })
 
-        if (filter.isEmpty() || listModel.isEmpty) {
+        if (listModel.isEmpty) {
             list.setSelectedValue(null, false)
         } else {
             // Improve keyboard navigation by auto-selecting the first result

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/utils.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/utils.kt
@@ -52,3 +52,110 @@ fun PsiFile.allPreprocessorDirectiveComments(): List<PsiComment> {
     return PsiTreeUtil.findChildrenOfType(this, PsiComment::class.java)
         .filter { it.text.startsWith(directivePrefix) }
 }
+
+data class PreprocessorContainingBlock(
+    val directives: List<PsiComment>,
+    val startIndex: Int,
+    val endIndex: Int,
+    val innerBlocks: List<IntRange>
+) {
+    companion object {
+        fun getFor(offset: Int, directives: List<PsiComment>): PreprocessorContainingBlock? {
+
+            // First lets check this caret pos is actually between some directives before we get any more complex
+            val previous = directives.lastOrNull { it.textRange.endOffset <= offset } ?: return null
+            val next = directives.firstOrNull { it.textRange.startOffset > offset } ?: return null
+
+            // Okay now lets find the containing block, this is a bit tricky because of possible nesting
+            // We will iterate backwards from the previous directive to find the start of the block
+            // and forwards from the next directive to find the end of the block
+            // We also need to keep track of any inner blocks we find along the way so they can be safely ignored later
+
+            val innerBlocks = mutableListOf<IntRange>()
+
+            // Iterate backwards to find the previous containing directive
+            val startIndex: Int
+            if (previous.text.startsWith("//#endif")) {
+                // Nested block, we need to find the matching block start for our level
+                var depth = 1
+                var index = directives.indexOf(previous)
+                var lastEnd = index
+                var find: Int? = null
+                while (index > 0) {
+                    index--
+                    val text = directives[index].text
+                    if (text.startsWith("//#endif")) {
+                        depth++
+                        if (depth == 1) {
+                            lastEnd = index
+                        }
+                    } else if (text.startsWith("//#if") || text.startsWith("//#ifdef")) {
+                        if (depth == 0) {
+                            find = index
+                            break
+                        }
+                        if (depth == 1) {
+                            innerBlocks.add(index..lastEnd)
+                        }
+                        depth--
+                    } else if (text.startsWith("//#else") || text.startsWith("//#elseif")) {
+                        if (depth == 0) {
+                            find = index
+                            break
+                        }
+                    }
+                }
+                startIndex = find ?: return null
+            } else {
+                // Simple case, just the previous directive of the same level
+                startIndex = directives.indexOf(previous)
+            }
+
+
+            // Now find the next directive to determine the end of the block, this basically repeats the above logic
+            val endIndex: Int
+            if (next.text.startsWith("//#if") || next.text.startsWith("//#ifdef")) {
+                // Nested block, we need to find the matching block end for our level
+                var depth = 1
+                var index = directives.indexOf(next)
+                var lastStart = index
+                var find: Int? = null
+                while (index < directives.size - 1) {
+                    index++
+                    val text = directives[index].text
+                    if (text.startsWith("//#if") || text.startsWith("//#ifdef")) {
+                        depth++
+                        if (depth == 1) {
+                            lastStart = index
+                        }
+                    } else if (text.startsWith("//#endif")) {
+                        if (depth == 0) {
+                            find = index
+                            break
+                        }
+                        if (depth == 1) {
+                            innerBlocks.add(lastStart..index)
+                        }
+                        depth--
+                    } else if (text.startsWith("//#else") || text.startsWith("//#elseif")) {
+                        if (depth == 0) {
+                            find = index
+                            break
+                        }
+                    }
+                }
+                endIndex = find ?: return null
+            } else {
+                // Simple case, just the next directive of the same level
+                endIndex = directives.indexOf(next)
+            }
+
+            return PreprocessorContainingBlock(
+                directives,
+                startIndex,
+                endIndex,
+                innerBlocks
+            )
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,5 +31,11 @@
 				description="Jump from or to this file in the preprocessed source. Will not update those source files, so you might need to build your project to update those files.">
 			<add-to-group group-id="ToolsMenu" anchor="last"/>
 		</action>
-	</actions>
+        <action id="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleAction"
+                class="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleAction"
+                text="Toggle Preprocessor Comments Of Block &quot;//$$ &quot;"
+                description="Toggles all preprocessor comments (//$$ ) in the selected block">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+    </actions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,10 +31,16 @@
 				description="Jump from or to this file in the preprocessed source. Will not update those source files, so you might need to build your project to update those files.">
 			<add-to-group group-id="ToolsMenu" anchor="last"/>
 		</action>
-        <action id="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleAction"
-                class="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleAction"
+        <action id="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleBlockAction"
+                class="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleBlockAction"
                 text="Toggle Preprocessor Comments Of Block &quot;//$$ &quot;"
                 description="Toggles all preprocessor comments (//$$ ) in the selected block">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleLineAction"
+                class="org.polyfrost.intelliprocessor.action.PreprocessorCommentToggleLineAction"
+                text="Toggle Preprocessor Comments Of Lines &quot;//$$ &quot;"
+                description="Toggles all preprocessor comments (//$$ ) in the selected lines">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </action>
     </actions>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- added an action to toggle all preprocessor comments `//$$ ` for the selected lines
- added an action to toggle all preprocessor comments `//$$ ` for the entire preprocessor block the caret is within
- having ! before a condition identifer is no longer highlighted as an error, e.g. `!FABRIC`
- further keyboard navigation improvements to file jump action

## How to test
<!-- Provide steps to test this PR -->
add keybinds for the actions and use them :/

use arrow navigation in the file jump action 

look at the line  `//#if !FABRIC` and see its not highlighted in error

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- added an action to toggle all preprocessor comments `//$$ ` for the selected lines
- added an action to toggle all preprocessor comments `//$$ ` for the entire preprocessor block the caret is within
- having ! before a condition identifer is no longer highlighted as an error, e.g. `!FABRIC`
- further keyboard navigation improvements to file jump action
```
