### PR TITLE
Misc: Improvements

### DIFF
--- a/src/main/kotlin/org/polyfrost/intelliprocessor/PreprocessorImport.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/PreprocessorImport.kt
@@ -22,7 +22,7 @@ class PreprocessorImport : ImportOptimizer {
         if (!hasPreprocessorDirectives(imports)) {
             return LanguageImportStatements.INSTANCE
                 .allForLanguage(file.language)
-                .first { it !is JavaImportOptimizer }
+                .first { it is JavaImportOptimizer }
                 .processFile(file)
         }
 

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginConfigurable.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginConfigurable.kt
@@ -17,7 +17,9 @@ class PluginConfigurable : Configurable {
     private lateinit var inspectionHighlightCommentsNotMatchingIfIndentsCheckbox: JCheckBox
     private lateinit var hideUnmatchedVersionsCheckbox: JCheckBox
     private lateinit var addPreprocessorCommentOnEnterCheckbox: JCheckBox
-
+    private lateinit var colorNestedPreprocessorCommentsCheckbox: JCheckBox
+    private lateinit var colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox: JCheckBox
+    private lateinit var inspectionHighlightContentNotMatchingIfIndentsCheckbox: JCheckBox
 
     override fun getDisplayName(): String = "IntelliProcessor"
 
@@ -57,6 +59,16 @@ class PluginConfigurable : Configurable {
         addPreprocessorCommentOnEnterCheckbox = JCheckBox("Add preprocessor comment '//$$ ' automatically to new lines in a disabled preprocessor block")
             .tooltip("When pressing Enter inside a disabled preprocessor block, automatically adds a preprocessor comment '//$$ ' to the new line.")
 
+        colorNestedPreprocessorCommentsCheckbox = JCheckBox("Color nested preprocessor comments differently")
+            .tooltip("Colors preprocessor comments inside nested preprocessor blocks with a different color for better visibility.")
+
+        colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox = JCheckBox("Only recolor nested preprocessor comments when in-line with each other")
+            .tooltip("Only applies the different color to nested preprocessor comments when their indents align.")
+
+        inspectionHighlightContentNotMatchingIfIndentsCheckbox = JCheckBox("Highlight lines indented less than their \"if\"'s indent")
+                .tooltip("Highlights lines of code inside preprocessor blocks that are indented less than the corresponding \"if\" directive.\n" +
+                    "This does break preprocessing.")
+
         // Arrange components
 
         fun titledBlock(str: String, block: JPanel.() -> Unit): JPanel = JPanel().apply {
@@ -78,6 +90,9 @@ class PluginConfigurable : Configurable {
             add(titledBlock("Formatting") {
                 add(inspectionHighlightNonIndentedNestedIfsCheckbox)
                 add(inspectionHighlightCommentsNotMatchingIfIndentsCheckbox)
+                add(inspectionHighlightContentNotMatchingIfIndentsCheckbox)
+                add(colorNestedPreprocessorCommentsCheckbox)
+                add(colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox)
             })
 
             add(titledBlock("Jump To Pre-Processed File Action") {
@@ -104,6 +119,9 @@ class PluginConfigurable : Configurable {
                 || inspectionHighlightCommentsNotMatchingIfIndentsCheckbox.isSelected != PluginSettings.instance.inspectionHighlightCommentsNotMatchingIfIndents
                 || hideUnmatchedVersionsCheckbox.isSelected != PluginSettings.instance.hideUnmatchedVersions
                 || addPreprocessorCommentOnEnterCheckbox.isSelected != PluginSettings.instance.addPreprocessorCommentOnEnter
+                || colorNestedPreprocessorCommentsCheckbox.isSelected != PluginSettings.instance.colorNestedPreprocessorComments
+                || colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected != PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent
+                || inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected != PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents
 
     override fun apply() {
         PluginSettings.instance.foldAllBlocksByDefault = foldAllBlocksByDefaultCheckbox.isSelected
@@ -112,6 +130,9 @@ class PluginConfigurable : Configurable {
         PluginSettings.instance.inspectionHighlightCommentsNotMatchingIfIndents = inspectionHighlightCommentsNotMatchingIfIndentsCheckbox.isSelected
         PluginSettings.instance.hideUnmatchedVersions = hideUnmatchedVersionsCheckbox.isSelected
         PluginSettings.instance.addPreprocessorCommentOnEnter = addPreprocessorCommentOnEnterCheckbox.isSelected
+        PluginSettings.instance.colorNestedPreprocessorComments = colorNestedPreprocessorCommentsCheckbox.isSelected
+        PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent = colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected
+        PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents = inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected
     }
 
     override fun reset() {
@@ -121,5 +142,8 @@ class PluginConfigurable : Configurable {
         inspectionHighlightCommentsNotMatchingIfIndentsCheckbox.isSelected = PluginSettings.instance.inspectionHighlightCommentsNotMatchingIfIndents
         hideUnmatchedVersionsCheckbox.isSelected = PluginSettings.instance.hideUnmatchedVersions
         addPreprocessorCommentOnEnterCheckbox.isSelected = PluginSettings.instance.addPreprocessorCommentOnEnter
+        colorNestedPreprocessorCommentsCheckbox.isSelected = PluginSettings.instance.colorNestedPreprocessorComments
+        colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected = PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent
+        inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected = PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents
     }
 }

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginConfigurable.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginConfigurable.kt
@@ -20,6 +20,7 @@ class PluginConfigurable : Configurable {
     private lateinit var colorNestedPreprocessorCommentsCheckbox: JCheckBox
     private lateinit var colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox: JCheckBox
     private lateinit var inspectionHighlightContentNotMatchingIfIndentsCheckbox: JCheckBox
+    private lateinit var inspectionRequireJavaKotlinSpacingInConditionsCheckbox: JCheckBox
 
     override fun getDisplayName(): String = "IntelliProcessor"
 
@@ -69,6 +70,9 @@ class PluginConfigurable : Configurable {
                 .tooltip("Highlights lines of code inside preprocessor blocks that are indented less than the corresponding \"if\" directive.\n" +
                     "This does break preprocessing.")
 
+        inspectionRequireJavaKotlinSpacingInConditionsCheckbox = JCheckBox("Highlight non-standard Java / Kotlin spacing around operators in preprocessor conditions")
+            .tooltip("Highlights improper use of spaces around operators in preprocessor conditions for improved readability.")
+
         // Arrange components
 
         fun titledBlock(str: String, block: JPanel.() -> Unit): JPanel = JPanel().apply {
@@ -93,6 +97,7 @@ class PluginConfigurable : Configurable {
                 add(inspectionHighlightContentNotMatchingIfIndentsCheckbox)
                 add(colorNestedPreprocessorCommentsCheckbox)
                 add(colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox)
+                add(inspectionRequireJavaKotlinSpacingInConditionsCheckbox)
             })
 
             add(titledBlock("Jump To Pre-Processed File Action") {
@@ -122,6 +127,7 @@ class PluginConfigurable : Configurable {
                 || colorNestedPreprocessorCommentsCheckbox.isSelected != PluginSettings.instance.colorNestedPreprocessorComments
                 || colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected != PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent
                 || inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected != PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents
+                || inspectionRequireJavaKotlinSpacingInConditionsCheckbox.isSelected != PluginSettings.instance.inspectionRequireJavaKotlinSpacingInConditions
 
     override fun apply() {
         PluginSettings.instance.foldAllBlocksByDefault = foldAllBlocksByDefaultCheckbox.isSelected
@@ -133,6 +139,7 @@ class PluginConfigurable : Configurable {
         PluginSettings.instance.colorNestedPreprocessorComments = colorNestedPreprocessorCommentsCheckbox.isSelected
         PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent = colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected
         PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents = inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected
+        PluginSettings.instance.inspectionRequireJavaKotlinSpacingInConditions = inspectionRequireJavaKotlinSpacingInConditionsCheckbox.isSelected
     }
 
     override fun reset() {
@@ -145,5 +152,6 @@ class PluginConfigurable : Configurable {
         colorNestedPreprocessorCommentsCheckbox.isSelected = PluginSettings.instance.colorNestedPreprocessorComments
         colorNestedPreprocessorCommentsOnlyOnSameIndentCheckbox.isSelected = PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent
         inspectionHighlightContentNotMatchingIfIndentsCheckbox.isSelected = PluginSettings.instance.inspectionHighlightContentNotMatchingIfIndents
+        inspectionRequireJavaKotlinSpacingInConditionsCheckbox.isSelected = PluginSettings.instance.inspectionRequireJavaKotlinSpacingInConditions
     }
 }

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginSettings.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginSettings.kt
@@ -11,10 +11,13 @@ import com.intellij.openapi.components.service
 class PluginSettings : PersistentStateComponent<PluginSettings> {
     var foldAllBlocksByDefault: Boolean = false
     var foldInactiveBlocksByDefault: Boolean = true
-    var inspectionHighlightNonIndentedNestedIfs: Boolean = true
+    var inspectionHighlightNonIndentedNestedIfs: Boolean = false
     var inspectionHighlightCommentsNotMatchingIfIndents: Boolean = true
     var hideUnmatchedVersions: Boolean = false
     var addPreprocessorCommentOnEnter = true
+    var colorNestedPreprocessorComments = true
+    var colorNestedPreprocessorCommentsOnlyOnSameIndent = false
+    var inspectionHighlightContentNotMatchingIfIndents = true
 
     override fun getState(): PluginSettings = this
 
@@ -25,6 +28,9 @@ class PluginSettings : PersistentStateComponent<PluginSettings> {
         this.inspectionHighlightCommentsNotMatchingIfIndents = state.inspectionHighlightCommentsNotMatchingIfIndents
         this.hideUnmatchedVersions = state.hideUnmatchedVersions
         this.addPreprocessorCommentOnEnter = state.addPreprocessorCommentOnEnter
+        this.colorNestedPreprocessorComments = state.colorNestedPreprocessorComments
+        this.colorNestedPreprocessorCommentsOnlyOnSameIndent = state.colorNestedPreprocessorCommentsOnlyOnSameIndent
+        this.inspectionHighlightContentNotMatchingIfIndents = state.inspectionHighlightContentNotMatchingIfIndents
     }
 
     companion object {

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginSettings.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/config/PluginSettings.kt
@@ -18,6 +18,7 @@ class PluginSettings : PersistentStateComponent<PluginSettings> {
     var colorNestedPreprocessorComments = true
     var colorNestedPreprocessorCommentsOnlyOnSameIndent = false
     var inspectionHighlightContentNotMatchingIfIndents = true
+    var inspectionRequireJavaKotlinSpacingInConditions = false
 
     override fun getState(): PluginSettings = this
 
@@ -31,6 +32,7 @@ class PluginSettings : PersistentStateComponent<PluginSettings> {
         this.colorNestedPreprocessorComments = state.colorNestedPreprocessorComments
         this.colorNestedPreprocessorCommentsOnlyOnSameIndent = state.colorNestedPreprocessorCommentsOnlyOnSameIndent
         this.inspectionHighlightContentNotMatchingIfIndents = state.inspectionHighlightContentNotMatchingIfIndents
+        this.inspectionRequireJavaKotlinSpacingInConditions = state.inspectionRequireJavaKotlinSpacingInConditions
     }
 
     companion object {

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
@@ -82,6 +82,7 @@ class PreprocessorSyntaxHighlight(private val project: Project) : HighlightVisit
     private val doIdentMatchWarn get() = PluginSettings.instance.inspectionHighlightCommentsNotMatchingIfIndents
     private val colorNestedIndents get() = PluginSettings.instance.colorNestedPreprocessorComments
     private val colorNestedIndentsOnlyIfInLine get() = PluginSettings.instance.colorNestedPreprocessorCommentsOnlyOnSameIndent
+    private val doSpacingWarn get() = PluginSettings.instance.inspectionRequireJavaKotlinSpacingInConditions
 
     override fun suitableForFile(file: PsiFile): Boolean {
         return file.fileType.name.uppercase(Locale.ROOT) in ALLOWED_FILE_TYPES
@@ -210,6 +211,8 @@ class PreprocessorSyntaxHighlight(private val project: Project) : HighlightVisit
 
             EXPR_PATTERN.matchEntire(trimmed)?.let { m ->
                 m.groups[1]?.toHighlight(element, position)?.let(holder::add)
+                if (doSpacingWarn && !trimmed.contains(" ${m.groups[2]?.value} "))
+                    warn(element, "Operator \"${m.groups[2]?.value}\" should be surrounded by spaces for clarity & consistency with Java / Kotlin styling.")
                 m.groups[3]?.toHighlight(element, position)?.let(holder::add)
             } ?: run {
                 IDENTIFIER_PATTERN.matchEntire(trimmed)?.let { idMatch ->

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/editor/PreprocessorSyntaxHighlight.kt
@@ -23,6 +23,7 @@ import com.intellij.ui.JBColor
 import org.polyfrost.intelliprocessor.ALLOWED_FILE_TYPES
 import org.polyfrost.intelliprocessor.Scope
 import org.polyfrost.intelliprocessor.config.PluginSettings
+import org.polyfrost.intelliprocessor.utils.PreprocessorVersion.Companion.toPreprocessorIntOrNull
 import java.awt.Color
 import java.util.*
 
@@ -349,8 +350,8 @@ class PreprocessorSyntaxHighlight(private val project: Project) : HighlightVisit
 
     private fun MatchGroup.toHighlight(element: PsiCommentImpl, offset: Int): HighlightInfo? {
         val trimmed = value.trim()
-        val type = if (trimmed.toIntOrNull() != null) NUMBER_TYPE else IDENTIFIER_TYPE
-        val attr = if (trimmed.toIntOrNull() != null) NUMBER_ATTRIBUTES else IDENTIFIER_ATTRIBUTES
+        val type = if (trimmed.toPreprocessorIntOrNull() != null) NUMBER_TYPE else IDENTIFIER_TYPE
+        val attr = if (trimmed.toPreprocessorIntOrNull() != null) NUMBER_ATTRIBUTES else IDENTIFIER_ATTRIBUTES
         return HighlightInfo.newHighlightInfo(type)
             .textAttributes(attr)
             .range(

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/PreprocessorConditions.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/PreprocessorConditions.kt
@@ -3,6 +3,7 @@ package org.polyfrost.intelliprocessor.utils
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.startOffset
+import org.polyfrost.intelliprocessor.utils.PreprocessorVersion.Companion.toPreprocessorIntOrNull
 
 
 class PreprocessorConditions private constructor(
@@ -176,7 +177,7 @@ class PreprocessorConditions private constructor(
             val (operator, rhsStr) = match.destructured
 
 
-            val rhs = rhsStr.toIntOrNull()
+            val rhs = rhsStr.toPreprocessorIntOrNull()
                 ?: return logAndNull("Could not evaluate version number in MC condition: $condition")
 
             val compare = currentVersion.mc

--- a/src/main/kotlin/org/polyfrost/intelliprocessor/utils/PreprocessorVersion.kt
+++ b/src/main/kotlin/org/polyfrost/intelliprocessor/utils/PreprocessorVersion.kt
@@ -15,7 +15,7 @@ class PreprocessorVersion private constructor(val mc: Int, val loader: String) {
         val NULL = PreprocessorVersion(0, "null")
 
         val String.preprocessorVersion: PreprocessorVersion? get() {
-            val int = makeComparable(this) ?: return null
+            val int = sugarToInt(this) ?: return null
             val loader = split("-").getOrNull(1) ?: return null
             return PreprocessorVersion(int, loader)
         }
@@ -53,8 +53,17 @@ class PreprocessorVersion private constructor(val mc: Int, val loader: String) {
             return Files.readString(versionFile).trim()
         }
 
+        /**
+         * Converts a preprocessor version string to an integer.
+         * Supports both sugar version format (e.g., `1.16.5`) and integer format (e.g., `11605`).
+         */
+        fun String.toPreprocessorIntOrNull() : Int? =
+            if (this.contains(".")) sugarToInt(this)
+            else this.toIntOrNull()
+
+
         private val regex = "(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?".toRegex()
-        private fun makeComparable(version: String): Int? {
+        private fun sugarToInt(version: String): Int? {
             val match = regex.find(version) ?: return null
             val groups = match.groups
 


### PR DESCRIPTION

<img width="783" height="423" alt="image" src="https://github.com/user-attachments/assets/2b4cd900-1d5f-496e-b4c6-b23817b57a6e" />


## Description
- added option to colour nested preprocessor blocks (kinda like rainbow brackets)
- added error highlight on code not indented further than the containing preprocessor block
- added optional formatting warning when operator format doesnt match java / kotlin styling. e.g. `MC > 1.21.2` rather than `MC>1.21.2`
- fixed the same error and warn highlights appearing multiple times for the same line
- fixed condition checks and highlighting for sugared version numbering e.g. `1.21.6` as opposed to `12106`
- added optional formatting warning when operator format doesnt match java / kotlin styling. e.g. `MC > 1.21.2` rather than `MC>1.21.2`

## Related Issue(s)
- fixed #16 from crashing, (not sure what the import optimizer is meant to do otherwise though)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
- added option to colour nested preprocessor blocks (kinda like rainbow brackets)
- added error highlight on code not indented further than the containing preprocessor block
- added optional formatting warning when operator format doesnt match java / kotlin styling. e.g. `MC > 1.21.2` rather than `MC>1.21.2`
- fixed the same error and warn highlights appearing multiple times for the same line
- fixed condition checks and highlighting for sugared version numbering e.g. `1.21.6` as opposed to `12106`
- added optional formatting warning when operator format doesnt match java / kotlin styling. e.g. `MC > 1.21.2` rather than `MC>1.21.2`
- fixed a crash related to optimising imports
```